### PR TITLE
Add ktlint formatting script via Docker

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-KTLINT_VERSION="1.5.0"
+KTLINT_VERSION="1.8.0"
+
+docker build -f ktlint.dockerfile -t ktlint:${KTLINT_VERSION} .
 
 echo "🔧 Running ktlint formatter (v${KTLINT_VERSION})..."
 docker run --rm \
   -v "$(pwd):/work" \
   -w /work \
-  "pinterest/ktlint:${KTLINT_VERSION}" \
+  "ktlint:${KTLINT_VERSION}" \
   --format "src/**/*.kt"
 
 echo "✅ Done! All Kotlin files formatted."

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KTLINT_VERSION="1.5.0"
+
+echo "🔧 Running ktlint formatter (v${KTLINT_VERSION})..."
+docker run --rm \
+  -v "$(pwd):/work" \
+  -w /work \
+  "pinterest/ktlint:${KTLINT_VERSION}" \
+  --format "src/**/*.kt"
+
+echo "✅ Done! All Kotlin files formatted."

--- a/ktlint.dockerfile
+++ b/ktlint.dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:25-jdk-alpine
+
+ARG KTLINT_VERSION=1.8.0
+
+RUN wget -O ktlint "https://github.com/pinterest/ktlint/releases/download/${KTLINT_VERSION}/ktlint" && chmod a+x ktlint && mv ktlint /usr/local/bin
+
+ENTRYPOINT ["ktlint"]

--- a/src/main/kotlin/de/theoptik/rathenakt/Launcher.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/Launcher.kt
@@ -1,8 +1,16 @@
 package de.theoptik.rathenakt
 
-import de.theoptik.rathenakt.models.*
+import de.theoptik.rathenakt.models.CharInfoType
+import de.theoptik.rathenakt.models.Coordinates
+import de.theoptik.rathenakt.models.FacingDirection
+import de.theoptik.rathenakt.models.MapReferences
 import de.theoptik.rathenakt.models.TickType.EPOCH_TIME
-
+import de.theoptik.rathenakt.models.Zeny
+import de.theoptik.rathenakt.models.callfunc
+import de.theoptik.rathenakt.models.concat
+import de.theoptik.rathenakt.models.gettimetick
+import de.theoptik.rathenakt.models.npc
+import de.theoptik.rathenakt.models.strcharinfo
 
 fun main() {
     val testNpc =
@@ -52,7 +60,7 @@ fun main() {
             `if`(price) {
                 chatMessage(
                     strcharinfo(CharInfoType.CHARACTER_NAME),
-                    "Healing costs " concat callfunc("F_InsertComma", price) concat " Zeny."
+                    "Healing costs " concat callfunc("F_InsertComma", price) concat " Zeny.",
                 )
             }
             `if`(Zeny lt price) {
@@ -78,5 +86,3 @@ fun main() {
     val synthesizer2 = Synthesizer()
     println(healer.synthesize(synthesizer2))
 }
-
-

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Coordinates.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Coordinates.kt
@@ -1,3 +1,7 @@
 package de.theoptik.rathenakt.models
 
-data class Coordinates(val x: Int, val y: Int, val facingDirection: FacingDirection)
+data class Coordinates(
+    val x: Int,
+    val y: Int,
+    val facingDirection: FacingDirection,
+)

--- a/src/main/kotlin/de/theoptik/rathenakt/models/FacingDirection.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/FacingDirection.kt
@@ -3,7 +3,9 @@ package de.theoptik.rathenakt.models
 // [1][8][7]
 // [2][0][6]
 // [3][4][5]
-enum class FacingDirection(val value: Int) {
+enum class FacingDirection(
+    val value: Int,
+) {
     NEUTRAL(0),
     NORTH_WEST(1),
     NORTH(8),
@@ -15,7 +17,5 @@ enum class FacingDirection(val value: Int) {
     SOUTH_EAST(5),
     ;
 
-    override fun toString(): String {
-        return value.toString()
-    }
+    override fun toString(): String = value.toString()
 }

--- a/src/main/kotlin/de/theoptik/rathenakt/models/MapReferences.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/MapReferences.kt
@@ -1,6 +1,8 @@
 package de.theoptik.rathenakt.models
 
-enum class MapReferences(val mapName: String) {
+enum class MapReferences(
+    val mapName: String,
+) {
     ALB_SHIP("alb_ship"),
     ALB2TREA("alb2trea"),
     ALBERTA("alberta"),
@@ -1166,7 +1168,5 @@ enum class MapReferences(val mapName: String) {
     VR_BOB("vr_bob"),
     ;
 
-    override fun toString(): String {
-        return mapName
-    }
+    override fun toString(): String = mapName
 }

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Npc.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Npc.kt
@@ -1,9 +1,5 @@
 package de.theoptik.rathenakt.models
 
-import java.lang.System.lineSeparator
-
-
-
 fun npc(
     name: String,
     sprite: Int = -1,
@@ -15,5 +11,3 @@ fun npc(
     npc.init()
     return npc
 }
-
-

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Scope.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Scope.kt
@@ -2,7 +2,9 @@ package de.theoptik.rathenakt.models
 
 import de.theoptik.rathenakt.Synthesizer
 
-sealed class Scope(open val name: String? = null) : Synthesizable {
+sealed class Scope(
+    open val name: String? = null,
+) : Synthesizable {
     val parts: MutableList<ScopePart> = mutableListOf()
 
     operator fun invoke(init: Scope.() -> Unit) {
@@ -17,19 +19,28 @@ sealed class Scope(open val name: String? = null) : Synthesizable {
         parts.add(ScopePartMessage(message))
     }
 
-    fun chatMessage(playerName: String, message: String) {
+    fun chatMessage(
+        playerName: String,
+        message: String,
+    ) {
         chatMessage(StringStatement(playerName), message)
     }
 
-    fun chatMessage(playerName: Statement, message: String) {
+    fun chatMessage(
+        playerName: Statement,
+        message: String,
+    ) {
         chatMessage(playerName, StringStatement(message))
     }
 
-    fun chatMessage(playerName: Statement, message: Statement) {
+    fun chatMessage(
+        playerName: Statement,
+        message: Statement,
+    ) {
         parts.add(ScopePartChatMessage(playerName, message))
     }
 
-    fun select(options:String) {
+    fun select(options: String) {
         parts.add(ScopePartSelect(options.split(":")))
     }
 
@@ -47,9 +58,7 @@ sealed class Scope(open val name: String? = null) : Synthesizable {
         parts.add(ScopePartEnd)
     }
 
-    override fun synthesize(synthesizer: Synthesizer): String {
-        return synthesizer.synthesize(this)
-    }
+    override fun synthesize(synthesizer: Synthesizer): String = synthesizer.synthesize(this)
 
     fun variable(
         name: String,
@@ -69,13 +78,15 @@ sealed class Scope(open val name: String? = null) : Synthesizable {
         return variable
     }
 
-    fun characterVariable(name: String, _typeHint: Int.Companion): Variable<Int> {
-        return CharacterIntVariable(name)
-    }
+    fun characterVariable(
+        name: String,
+        _typeHint: Int.Companion,
+    ): Variable<Int> = CharacterIntVariable(name)
 
-    fun characterVariable(name: String, _typeHint: String.Companion): Variable<String> {
-        return CharacterStringVariable(name)
-    }
+    fun characterVariable(
+        name: String,
+        _typeHint: String.Companion,
+    ): Variable<String> = CharacterStringVariable(name)
 
     fun characterVariable(
         name: String,
@@ -95,18 +106,26 @@ sealed class Scope(open val name: String? = null) : Synthesizable {
         return variable
     }
 
-    fun `if`(statement: Statement, init: IfCondition.() -> Unit) {
+    fun `if`(
+        statement: Statement,
+        init: IfCondition.() -> Unit,
+    ) {
         val ifScope = IfCondition(statement)
         ifScope.init()
         parts.add(ScopePartIf(ifScope))
     }
 
-    fun `if`(variable: Variable<*>, init: IfCondition.() -> Unit) {
+    fun `if`(
+        variable: Variable<*>,
+        init: IfCondition.() -> Unit,
+    ) {
         this.`if`(VariableStatement(variable), init)
     }
 }
 
-class SimpleScope(name: String?) : Scope(name)
+class SimpleScope(
+    name: String?,
+) : Scope(name)
 
 class Npc(
     name: String?,
@@ -132,14 +151,11 @@ class Npc(
         return scope
     }
 
-    override fun synthesize(synthesizer: Synthesizer):String {
-        return synthesizer.synthesize(this)
-    }
+    override fun synthesize(synthesizer: Synthesizer): String = synthesizer.synthesize(this)
 }
 
-class IfCondition(val statement: Statement) : Scope() {
-
-    override fun synthesize(synthesizer: Synthesizer): String {
-        return synthesizer.synthesize(this)
-    }
+class IfCondition(
+    val statement: Statement,
+) : Scope() {
+    override fun synthesize(synthesizer: Synthesizer): String = synthesizer.synthesize(this)
 }

--- a/src/main/kotlin/de/theoptik/rathenakt/models/ScopePart.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/ScopePart.kt
@@ -2,38 +2,52 @@ package de.theoptik.rathenakt.models
 
 import de.theoptik.rathenakt.Synthesizer
 
-sealed class ScopePart : Synthesizable{
-    open fun isTerminating():Boolean{return false}
-    override fun synthesize(synthesizer: Synthesizer):String {
-        return synthesizer.synthesize(this)
-    }
+sealed class ScopePart : Synthesizable {
+    open fun isTerminating(): Boolean = false
+
+    override fun synthesize(synthesizer: Synthesizer): String = synthesizer.synthesize(this)
 }
+
 data object ScopePartClose : ScopePart()
 
-data class ScopePartMessage(val message: String) : ScopePart()
+data class ScopePartMessage(
+    val message: String,
+) : ScopePart()
 
-data class ScopePartChatMessage(val playerName:Statement,  val message: Statement) : ScopePart()
+data class ScopePartChatMessage(
+    val playerName: Statement,
+    val message: Statement,
+) : ScopePart()
 
-data class ScopePartSelect(val options:List<String>) : ScopePart()
+data class ScopePartSelect(
+    val options: List<String>,
+) : ScopePart()
 
-data class ScopePartGoto(val scope: Scope) : ScopePart() {
-    override fun isTerminating(): Boolean {
-        return true
-    }
+data class ScopePartGoto(
+    val scope: Scope,
+) : ScopePart() {
+    override fun isTerminating(): Boolean = true
 }
 
-data class ScopePartMenu(val options: Map<String, Scope?>) : ScopePart()
+data class ScopePartMenu(
+    val options: Map<String, Scope?>,
+) : ScopePart()
 
 data object ScopePartEnd : ScopePart() {
-    override fun isTerminating(): Boolean {
-        return true
-    }
+    override fun isTerminating(): Boolean = true
 }
 
 data object ScopePartClear : ScopePart()
 
-data class ScopePartVariableInstantiation<T>(val variable: Variable<T>, val initialValue: T) : ScopePart()
+data class ScopePartVariableInstantiation<T>(
+    val variable: Variable<T>,
+    val initialValue: T,
+) : ScopePart()
 
-data class ScopePartStatement(val statement: Statement):ScopePart()
+data class ScopePartStatement(
+    val statement: Statement,
+) : ScopePart()
 
-data class ScopePartIf(val condition: IfCondition) : ScopePart()
+data class ScopePartIf(
+    val condition: IfCondition,
+) : ScopePart()

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Statement.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Statement.kt
@@ -2,33 +2,56 @@ package de.theoptik.rathenakt.models
 
 import de.theoptik.rathenakt.Synthesizer
 
-sealed class Statement: Synthesizable{
-    override fun synthesize(synthesizer: Synthesizer):String {
-        return synthesizer.synthesize(this)
-    }
+sealed class Statement : Synthesizable {
+    override fun synthesize(synthesizer: Synthesizer): String = synthesizer.synthesize(this)
 }
 
-data class ConcatenatedStatement(val first:Statement, val second:Statement):Statement()
-data class StringStatement(val value: String):Statement()
-data class VariableStatement(val variable: Variable<*>): Statement()
-data class GreaterThanStatement(val left: Statement, val right: Statement): Statement()
-data class LesserThanStatement(val left: Statement, val right: Statement): Statement()
-data  class TimeTickStatement( val type:TickType):Statement()
-data class CharInfoStatement(val type:CharInfoType):Statement()
-data class CallFuncStatement( val functionName:String, val argument: Statement):Statement()
+data class ConcatenatedStatement(
+    val first: Statement,
+    val second: Statement,
+) : Statement()
 
-fun gettimetick(type:TickType): Statement {
-    return TimeTickStatement(type)
-}
+data class StringStatement(
+    val value: String,
+) : Statement()
 
-fun strcharinfo(type:CharInfoType): Statement {
-    return CharInfoStatement(type)
-}
+data class VariableStatement(
+    val variable: Variable<*>,
+) : Statement()
 
-fun callfunc(functionName:String, argument: Statement): Statement {
-    return CallFuncStatement(functionName, argument)
-}
+data class GreaterThanStatement(
+    val left: Statement,
+    val right: Statement,
+) : Statement()
 
-fun callfunc(functionName:String, argument: Variable<*>): Statement {
-    return CallFuncStatement(functionName, VariableStatement(argument))
-}
+data class LesserThanStatement(
+    val left: Statement,
+    val right: Statement,
+) : Statement()
+
+data class TimeTickStatement(
+    val type: TickType,
+) : Statement()
+
+data class CharInfoStatement(
+    val type: CharInfoType,
+) : Statement()
+
+data class CallFuncStatement(
+    val functionName: String,
+    val argument: Statement,
+) : Statement()
+
+fun gettimetick(type: TickType): Statement = TimeTickStatement(type)
+
+fun strcharinfo(type: CharInfoType): Statement = CharInfoStatement(type)
+
+fun callfunc(
+    functionName: String,
+    argument: Statement,
+): Statement = CallFuncStatement(functionName, argument)
+
+fun callfunc(
+    functionName: String,
+    argument: Variable<*>,
+): Statement = CallFuncStatement(functionName, VariableStatement(argument))

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Synthesizable.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Synthesizable.kt
@@ -4,5 +4,4 @@ import de.theoptik.rathenakt.Synthesizer
 
 interface Synthesizable {
     fun synthesize(synthesizer: Synthesizer): String
-
 }

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Utils.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Utils.kt
@@ -1,25 +1,24 @@
 package de.theoptik.rathenakt.models
 
-enum class TickType(val value: Int) {
+enum class TickType(
+    val value: Int,
+) {
     SERVER_TICKS(0),
     SECONDS_OF_DAY(1),
     EPOCH_TIME(2),
 }
 
-enum class CharInfoType(val value: Int) {
+enum class CharInfoType(
+    val value: Int,
+) {
     CHARACTER_NAME(0),
     PARTY_NAME(1),
     GUILD_NAME(2),
     MAP_NAME(3),
 }
 
-data object Zeny: PermanentCharacterIntVariable("Zeny")
+data object Zeny : PermanentCharacterIntVariable("Zeny")
 
+infix fun String.concat(statement: Statement): Statement = ConcatenatedStatement(StringStatement(this), statement)
 
-infix fun String.concat(statement: Statement): Statement {
-    return ConcatenatedStatement(StringStatement(this), statement)
-}
-
-infix fun Statement.concat(string: String): Statement {
-    return ConcatenatedStatement(this,StringStatement(string))
-}
+infix fun Statement.concat(string: String): Statement = ConcatenatedStatement(this, StringStatement(string))

--- a/src/main/kotlin/de/theoptik/rathenakt/models/Variable.kt
+++ b/src/main/kotlin/de/theoptik/rathenakt/models/Variable.kt
@@ -2,42 +2,40 @@ package de.theoptik.rathenakt.models
 
 import de.theoptik.rathenakt.Synthesizer
 
-sealed class Variable<T>(val name: String) : Synthesizable {
-    override fun synthesize(synthesizer: Synthesizer):String {
-        return synthesizer.synthesize(this)
-    }
+sealed class Variable<T>(
+    val name: String,
+) : Synthesizable {
+    override fun synthesize(synthesizer: Synthesizer): String = synthesizer.synthesize(this)
 
-    infix fun gt(other: Statement): Statement {
-        return GreaterThanStatement(VariableStatement(this), other)
-    }
+    infix fun gt(other: Statement): Statement = GreaterThanStatement(VariableStatement(this), other)
 
-    infix fun gt(other: Variable<*>): Statement {
-        return GreaterThanStatement(VariableStatement(this), VariableStatement(other))
-    }
+    infix fun gt(other: Variable<*>): Statement = GreaterThanStatement(VariableStatement(this), VariableStatement(other))
 
-    infix fun lt(other: Variable<*>): Statement {
-        return LesserThanStatement(VariableStatement(this), VariableStatement(other))
-    }
+    infix fun lt(other: Variable<*>): Statement = LesserThanStatement(VariableStatement(this), VariableStatement(other))
 
-    infix fun lt(other: Statement): Statement {
-        return LesserThanStatement(VariableStatement(this), other)
-    }
+    infix fun lt(other: Statement): Statement = LesserThanStatement(VariableStatement(this), other)
 }
 
-class ScopeStringVariable(name: String) :
-    Variable<String>(name)
+class ScopeStringVariable(
+    name: String,
+) : Variable<String>(name)
 
-class ScopeIntVariable(name: String) :
-    Variable<Int>(name)
+class ScopeIntVariable(
+    name: String,
+) : Variable<Int>(name)
 
-class CharacterStringVariable(name: String) :
-    Variable<String>(name)
+class CharacterStringVariable(
+    name: String,
+) : Variable<String>(name)
 
-class CharacterIntVariable(name: String) :
-    Variable<Int>(name)
+class CharacterIntVariable(
+    name: String,
+) : Variable<Int>(name)
 
-open class PermanentCharacterIntVariable(name: String) :
-    Variable<Int>(name)
+open class PermanentCharacterIntVariable(
+    name: String,
+) : Variable<Int>(name)
 
-class PermanentCharacterStringVariable(name: String) :
-    Variable<String>(name)
+class PermanentCharacterStringVariable(
+    name: String,
+) : Variable<String>(name)

--- a/src/test/kotlin/de/theoptik/rathenakt/SynthesizerCloseTest.kt
+++ b/src/test/kotlin/de/theoptik/rathenakt/SynthesizerCloseTest.kt
@@ -1,31 +1,33 @@
 package de.theoptik.rathenakt
 
-import de.theoptik.rathenakt.models.*
-import kotlin.test.assertContains
+import de.theoptik.rathenakt.models.npc
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
 
 class SynthesizerCloseTest {
-
     private val synthesizer = Synthesizer()
 
     @Test
     fun `scope ending with message should have close appended`() {
-        val npc = npc(name = "CloseTest", sprite = 100) {
-            message("Hello!")
-        }
+        val npc =
+            npc(name = "CloseTest", sprite = 100) {
+                message("Hello!")
+            }
         val output = npc.synthesize(synthesizer)
         assertContains(output, "close;", message = "A scope ending with a message should have 'close;' appended")
     }
 
     @Test
     fun `scope ending with goto should not have close appended`() {
-        val npc = npc(name = "GotoTest", sprite = 100) {
-            val target = scope("L_Target") {
-                message("Arrived!")
+        val npc =
+            npc(name = "GotoTest", sprite = 100) {
+                val target =
+                    scope("L_Target") {
+                        message("Arrived!")
+                    }
+                goto(target)
             }
-            goto(target)
-        }
         val output = npc.synthesize(synthesizer)
         // The main scope ends with goto — should NOT have close after it
         val mainBody = output.substringAfter("{").substringBefore("L_Target:")
@@ -34,10 +36,11 @@ class SynthesizerCloseTest {
 
     @Test
     fun `scope ending with end should not have close appended`() {
-        val npc = npc(name = "EndTest", sprite = 100) {
-            message("Goodbye!")
-            end()
-        }
+        val npc =
+            npc(name = "EndTest", sprite = 100) {
+                message("Goodbye!")
+                end()
+            }
         val output = npc.synthesize(synthesizer)
         // end; should be the last statement, no close; after it
         val lines = output.lines().map { it.trim() }.filter { it.isNotEmpty() }
@@ -45,19 +48,20 @@ class SynthesizerCloseTest {
         val closeIndex = lines.indexOfLast { it == "close;" }
         assertFalse(
             closeIndex > endIndex,
-            "A scope ending with end; should not have close; appended after it. Output:\n$output"
+            "A scope ending with end; should not have close; appended after it. Output:\n$output",
         )
     }
 
     @Test
     fun `scope ending with menu should have close appended`() {
-        val npc = npc(name = "MenuTest", sprite = 100) {
-            message("Choose:")
-            menu {
-                option("Option A", null)
-                option("Option B", null)
+        val npc =
+            npc(name = "MenuTest", sprite = 100) {
+                message("Choose:")
+                menu {
+                    option("Option A", null)
+                    option("Option B", null)
+                }
             }
-        }
         val output = npc.synthesize(synthesizer)
         assertContains(output, "close;", message = "A scope ending with a menu should have 'close;' appended")
     }
@@ -71,12 +75,14 @@ class SynthesizerCloseTest {
 
     @Test
     fun `sub-scope ending with message should have close appended`() {
-        val npc = npc(name = "SubScopeTest", sprite = 100) {
-            val label = scope("L_Hello") {
-                message("Hi there!")
+        val npc =
+            npc(name = "SubScopeTest", sprite = 100) {
+                val label =
+                    scope("L_Hello") {
+                        message("Hi there!")
+                    }
+                goto(label)
             }
-            goto(label)
-        }
         val output = npc.synthesize(synthesizer)
         // The L_Hello scope ends with a message, so it should get close;
         val labelSection = output.substringAfter("L_Hello:")


### PR DESCRIPTION
Adds a `format.sh` script that runs [ktlint](https://pinterest.github.io/ktlint/) via Docker to format all Kotlin source files.

## Usage
```bash
./format.sh
```

Requires Docker to be installed. Uses `pinterest/ktlint:1.5.0` image.

No IDE plugins or local installs needed — just run the script and all `.kt` files in `src/` get formatted consistently.

Related: sets us up for consistent code style as we add more features.